### PR TITLE
(maint) Rename the module internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# http_authorization
+# puppet_authorization
 
 #### Table of Contents
 
 1. [Overview](#overview)
 2. [Module Description - What the module does and why it is useful](#module-description)
-3. [Setup - The basics of getting started with http_authorization](#setup)
-    * [What http_authorization affects](#what-http_authorization-affects)
+3. [Setup - The basics of getting started with puppet_authorization](#setup)
+    * [What puppet_authorization affects](#what-puppet_authorization-affects)
     * [Setup requirements](#setup-requirements)
-    * [Beginning with http_authorization](#beginning-with-http_authorization)
+    * [Beginning with puppet_authorization](#beginning-with-puppet_authorization)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
@@ -31,7 +31,7 @@ management, etc.) this is the time to mention it.
 
 ## Setup
 
-### What http_authorization affects
+### What puppet_authorization affects
 
 * A list of files, packages, services, or operations that the module will alter,
   impact, or execute on the system it's installed on.
@@ -43,7 +43,7 @@ management, etc.) this is the time to mention it.
 If your module requires anything extra before setting up (pluginsync enabled,
 etc.), mention it here.
 
-### Beginning with http_authorization
+### Beginning with puppet_authorization
 
 The very basic steps needed for a user to get the module up and running.
 
@@ -60,17 +60,17 @@ the fancy stuff with your module here.
 
 ### Classes
 
-* [`http_authorization`](#class-http_authorization)
+* [`puppet_authorization`](#class-puppet_authorization)
 
 ### Defines
 
-* [`http_authorization::rule`](#define-http_authorizationrule)
+* [`puppet_authorization::rule`](#define-puppet_authorizationrule)
 
 ### Providers
 
-* [`http_authorization`](#provider-http_authorization)
+* [`puppet_authorization`](#provider-puppet_authorization)
 
-#### Class: `http_authorization`
+#### Class: `puppet_authorization`
 
 Main class, sets up the skeleton server auth.conf file if it doesn't exist.
 
@@ -84,7 +84,7 @@ Main class, sets up the skeleton server auth.conf file if it doesn't exist.
 
 * `path`: Absolute path for auth.conf. Defaults to `${::settings::confdir}/auth.conf`.
 
-#### Define: `http_authorization::rule`
+#### Define: `puppet_authorization::rule`
 
 Add individual rules to auth.conf.
 
@@ -110,7 +110,7 @@ Add individual rules to auth.conf.
 
 * `sort_order`: The sort order for the rule. Valid options: an integer. Defaults to `200`
 
-* `path`: The absolute path for the auth.conf file. Defaults to `$http_authorization::path`
+* `path`: The absolute path for the auth.conf file. Defaults to `$puppet_authorization::path`
 
 ## Limitations
 

--- a/lib/puppet/provider/hocon_setting/puppet_authorization.rb
+++ b/lib/puppet/provider/hocon_setting/puppet_authorization.rb
@@ -1,4 +1,4 @@
-Puppet::Type.type(:hocon_setting).provide(:http_authorization, :parent => Puppet::Type.type(:hocon_setting).provider(:ruby)) do
+Puppet::Type.type(:hocon_setting).provide(:puppet_authorization, :parent => Puppet::Type.type(:hocon_setting).provider(:ruby)) do
   def set_value(value_to_set)
     if resource[:type] == 'array_element'
       tmp_val = []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-class http_authorization (
+class puppet_authorization (
   Integer $version = 1,
   Boolean $allow_header_cert_info = false,
   Boolean $replace = false,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -1,4 +1,4 @@
-define http_authorization::rule (
+define puppet_authorization::rule (
   String $match_request_path,
   Enum['path', 'regex'] $match_request_type,
   Enum['present', 'absent'] $ensure = 'present',
@@ -9,7 +9,7 @@ define http_authorization::rule (
   Variant[Array, String, Undef] $match_request_method = undef,
   Hash $match_request_query_params = {},
   Integer $sort_order = 200,
-  String $path = $http_authorization::path,
+  String $path = $puppet_authorization::path,
 ) {
   if $match_request_method =~ String {
     validate_re($match_request_method, '^(put|post|get|head|delete)$') 
@@ -68,6 +68,6 @@ define http_authorization::rule (
     setting  => 'authorization.rules',
     value    => $rule,
     type     => 'array_element',
-    provider => 'http_authorization',
+    provider => 'puppet_authorization',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,11 +1,11 @@
 {
-  "name": "puppetlabs-http_authorization",
+  "name": "puppetlabs-puppet_authorization",
   "version": "0.1.0",
   "author": "puppetlabs",
   "summary": "Module to manage auth.conf.",
   "license": "Apache-2.0",
-  "source": "https://github.com/puppetlabs/puppetlabs-http_authorization",
-  "project_page": "https://github.com/puppetlabs/puppetlabs-http_authorization",
+  "source": "https://github.com/puppetlabs/puppetlabs-puppet_authorization",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-puppet_authorization",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},

--- a/spec/classes/puppet_authorization_spec.rb
+++ b/spec/classes/puppet_authorization_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-describe 'http_authorization' do
+describe 'puppet_authorization' do
   let(:facts) do
     { :concat_basedir => '/dne' }
   end

--- a/spec/defines/rules_spec.rb
+++ b/spec/defines/rules_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-describe 'http_authorization::rule', :type => :define do
+describe 'puppet_authorization::rule', :type => :define do
   let :pre_condition do
-    'class { "http_authorization": path => "/tmp/foo" }'
+    'class { "puppet_authorization": path => "/tmp/foo" }'
   end
 
   let :params do
@@ -40,7 +40,7 @@ describe 'http_authorization::rule', :type => :define do
         'sort-order'    => 200,
       },
       :type     => 'array_element',
-      :provider => 'http_authorization',
+      :provider => 'puppet_authorization',
     })}
   end
 
@@ -75,7 +75,7 @@ describe 'http_authorization::rule', :type => :define do
         'sort-order'    => 1,
       },
       :type     => 'array_element',
-      :provider => 'http_authorization',
+      :provider => 'puppet_authorization',
     })}
   end
 
@@ -103,7 +103,7 @@ describe 'http_authorization::rule', :type => :define do
         'sort-order'            => 200,
       },
       :type     => 'array_element',
-      :provider => 'http_authorization',
+      :provider => 'puppet_authorization',
     })}
   end
 


### PR DESCRIPTION
Prior to this commit, the module was named http_authorization.
During the public RFC process, several commenters noted that this
name is overly generic and doesn't accurately reflect the scope
of the module.

This commit renames all the internals to "puppet_authorization",
which was the name suggested by Nick Fagerlund the Nomenclator,
aka "Them What Names Things", and +1'ed by several others.

The spec tests pass as-is but in addition to merging this commit,
the repository itself will need a rename.
