### PR TITLE
(MAINT) Convert `puppet_authorization` class to define

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,31 +58,29 @@ the fancy stuff with your module here.
 
 ## Reference
 
-### Classes
-
-* [`puppet_authorization`](#class-puppet_authorization)
-
 ### Defines
 
+* [`puppet_authorization`](#define-puppet_authorization)
 * [`puppet_authorization::rule`](#define-puppet_authorizationrule)
 
 ### Providers
 
 * [`puppet_authorization`](#provider-puppet_authorization)
 
-#### Class: `puppet_authorization`
+#### Define: `puppet_authorization`
 
-Main class, sets up the skeleton server auth.conf file if it doesn't exist.
+Sets up the skeleton server auth.conf file if it doesn't exist.
 
 ##### Parameters (all optional)
 
-* `version`: The `authorization.version` setting in the server auth.conf. Valid options: an integer. Default: 1
+* `version`: The `authorization.version` setting in the server auth.conf. Valid options: an integer. Default: `1`.
 
-* `allow_header_cert_info`: The `authorization.allow-header-cert-info` setting in the server auth.conf. Valid options: `true`, `false`. Default: `false`
+* `allow_header_cert_info`: The `authorization.allow-header-cert-info` setting in the server auth.conf. Valid options: `true`, `false`. Default: `false`.
 
-* `replace`: Whether or not to replace existing file at `path`. If set to true this will cause the file to be regenerated on every puppet run. Valid options: `true`, `false`. Default: `false`
+* `replace`: Whether or not to replace existing file at `path`. If set to true this will cause the file to be regenerated on every puppet run. Valid options: `true`, `false`. Default: 
+`false`.
 
-* `path`: Absolute path for auth.conf. Defaults to `${::settings::confdir}/auth.conf`.
+* `path`: Absolute path for auth.conf. Defaults to `name`.
 
 #### Define: `puppet_authorization::rule`
 
@@ -92,7 +90,9 @@ Add individual rules to auth.conf.
 
 * `match_request_path`: Required. Valid options: a string.
 
-* `match_request_type`: Required. Valid options: `'path'`, `'regex'`
+* `match_request_type`: Required. Valid options: `'path'`, `'regex'`.
+
+* `path`: Required. The absolute path for the auth.conf file.
 
 * `ensure`: Whether to add or remove the rule. Valid options: `'present'`, `'absent'`. Defaults to `'present'`
 
@@ -106,11 +106,10 @@ Add individual rules to auth.conf.
 
 * `match_request_method`: The `method` setting for the `match_request` in the rule. Valid options: String or array of strings containing: `'put'`, `'post'`, `'get'`, `'head'`, `'delete'`. Defaults to `undef`.
 
-* `match_request_query_params`: The `query_params` setting for the `match_request` in the rule. Valid options: Hash. Defaults to `{}`
+* `match_request_query_params`: The `query_params` setting for the `match_request` in the rule. Valid options: Hash. Defaults to `{}`.
 
-* `sort_order`: The sort order for the rule. Valid options: an integer. Defaults to `200`
-
-* `path`: The absolute path for the auth.conf file. Defaults to `$puppet_authorization::path`
+* `sort_order`: The sort order for the rule. Valid options: an integer. 
+  Defaults to `200`.
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,40 +1,40 @@
-class puppet_authorization (
+define puppet_authorization (
   Integer $version = 1,
   Boolean $allow_header_cert_info = false,
   Boolean $replace = false,
-  String $path = '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+  String $path = $name,
 ){
   validate_absolute_path($path)
 
-  concat { 'server-auth.conf':
+  concat { $name:
     path    => $path,
     replace => $replace,
   }
 
-  concat::fragment { '00_header':
-    target  => 'server-auth.conf',
+  concat::fragment { "00_header_${name}":
+    target  => $name,
     content => "authorization: {
   rules: []
-"
+",
   }
 
-  concat::fragment { '99_footer':
-    target  => 'server-auth.conf',
+  concat::fragment { "99_footer_${name}":
+    target  => $name,
     content => "}
-"
+",
   }
 
-  hocon_setting { 'authorization.version':
+  hocon_setting { "authorization.version.${name}":
     path    => $path,
     setting => 'authorization.version',
     value   => $version,
-    require => Concat['server-auth.conf'],
+    require => Concat[$name],
   }
 
-  hocon_setting { 'authorization.allow-header-cert-info':
+  hocon_setting { "authorization.allow-header-cert-info.${name}":
     path    => $path,
     setting => 'authorization.allow-header-cert-info',
     value   => $allow_header_cert_info,
-    require => Concat['server-auth.conf'],
+    require => Concat[$name],
   }
 }

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -1,6 +1,7 @@
 define puppet_authorization::rule (
   String $match_request_path,
   Enum['path', 'regex'] $match_request_type,
+  String $path,
   Enum['present', 'absent'] $ensure = 'present',
   String $rule_name = $name,
   Variant[Array, String, Undef] $allow = undef,
@@ -8,8 +9,7 @@ define puppet_authorization::rule (
   Variant[Array, String, Undef] $deny = undef,
   Variant[Array, String, Undef] $match_request_method = undef,
   Hash $match_request_query_params = {},
-  Integer $sort_order = 200,
-  String $path = $puppet_authorization::path,
+  Integer $sort_order = 200
 ) {
   if $match_request_method =~ String {
     validate_re($match_request_method, '^(put|post|get|head|delete)$')
@@ -22,9 +22,11 @@ define puppet_authorization::rule (
   validate_absolute_path($path)
 
   if $allow_unauthenticated and ($allow or $deny) {
-    fail('$allow and $deny cannot be specified if $allow_unauthenticated is true')
+    fail(
+      '$allow and $deny cannot be specified if $allow_unauthenticated is true')
   } elsif ! $allow and ! $deny and ! $allow_unauthenticated {
-    fail('One of $allow or $deny is required if $allow_unauthenticated is false')
+    fail(
+      'One of $allow or $deny is required if $allow_unauthenticated is false')
   }
 
   if $match_request_method {

--- a/spec/defines/puppet_authorization_spec.rb
+++ b/spec/defines/puppet_authorization_spec.rb
@@ -3,29 +3,35 @@ describe 'puppet_authorization' do
   let(:facts) do
     { :concat_basedir => '/dne' }
   end
+  let(:title) do
+    '/tmp/foo'
+  end
 
   context 'defaults' do
-    it { is_expected.to contain_concat('server-auth.conf').with({
-      :path    => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+    it {is_expected.to contain_concat(title).with({
+      :path    => title,
       :replace => false,
     })}
 
-    it { is_expected.to contain_concat__fragment('00_header').with({
-      :target => 'server-auth.conf',
+    it { is_expected.to contain_concat__fragment("00_header_#{title}").with({
+      :target => title,
     }).with_content(/authorization: \{\n  rules: \[\]\n/)}
 
-    it { is_expected.to contain_concat__fragment('99_footer').with({
-      :target => 'server-auth.conf',
+    it { is_expected.to contain_concat__fragment("99_footer_#{title}").with({
+      :target => title,
     }).with_content(/\}\n/)}
 
-    it { is_expected.to contain_hocon_setting('authorization.version').that_requires('Concat[server-auth.conf]').with({
-      :path    => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+    it { is_expected.to contain_hocon_setting("authorization.version.#{title}").
+          that_requires("Concat[#{title}]").with({
+      :path    => title,
       :setting => 'authorization.version',
       :value   => 1,
     })}
 
-    it { is_expected.to contain_hocon_setting('authorization.allow-header-cert-info').that_requires('Concat[server-auth.conf]').with({
-      :path    => '/etc/puppetlabs/puppetserver/conf.d/auth.conf',
+    it { is_expected.to contain_hocon_setting(
+                            "authorization.allow-header-cert-info.#{title}").
+                            that_requires("Concat[#{title}]").with({
+      :path    => title,
       :setting => 'authorization.allow-header-cert-info',
       :value   => false,
     })}
@@ -41,26 +47,29 @@ describe 'puppet_authorization' do
       }
     end
 
-    it { is_expected.to contain_concat('server-auth.conf').with({
+    it { is_expected.to contain_concat(title).with({
       :path    => '/tmp/foo',
       :replace => true,
     })}
 
-    it { is_expected.to contain_concat__fragment('00_header').with({
-      :target => 'server-auth.conf',
+    it { is_expected.to contain_concat__fragment("00_header_#{title}").with({
+      :target => title,
     }).with_content(/authorization: \{\n  rules: \[\]\n/)}
 
-    it { is_expected.to contain_concat__fragment('99_footer').with({
-      :target => 'server-auth.conf',
+    it { is_expected.to contain_concat__fragment("99_footer_#{title}").with({
+      :target => title,
     }).with_content(/\}\n/)}
 
-    it { is_expected.to contain_hocon_setting('authorization.version').that_requires('Concat[server-auth.conf]').with({
+    it { is_expected.to contain_hocon_setting("authorization.version.#{title}").
+                            that_requires("Concat[#{title}]").with({
       :path    => '/tmp/foo',
       :setting => 'authorization.version',
       :value   => 2,
     })}
 
-    it { is_expected.to contain_hocon_setting('authorization.allow-header-cert-info').that_requires('Concat[server-auth.conf]').with({
+    it { is_expected.to contain_hocon_setting(
+                            "authorization.allow-header-cert-info.#{title}").
+                            that_requires("Concat[#{title}]").with({
       :path    => '/tmp/foo',
       :setting => 'authorization.allow-header-cert-info',
       :value   => true,

--- a/spec/defines/rules_spec.rb
+++ b/spec/defines/rules_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 describe 'puppet_authorization::rule', :type => :define do
   let :pre_condition do
-    'class { "puppet_authorization": path => "/tmp/foo" }'
+    'puppet_authorization { "/tmp/foo": }'
   end
 
   let :params do
     {
       :match_request_path => '/foo',
       :match_request_type => 'path',
+      :path => '/tmp/foo'
     }.merge(params_override)
   end
 
@@ -169,7 +170,9 @@ describe 'puppet_authorization::rule', :type => :define do
 
     context 'bad match_request_method 2' do
       it_behaves_like "fail" do
-        let(:params_override) {{ :match_request_method => ['put', 'post', 'get', 'head', 'delete', 'foo'] }}
+        let(:params_override) {{
+            :match_request_method =>
+                ['put', 'post', 'get', 'head', 'delete', 'foo'] }}
         let(:regex) { 'does not match' }
       end
     end

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -1,12 +1,9 @@
-# The baseline for module testing used by Puppet Labs is that each manifest
-# should have a corresponding test manifest that declares that class or defined
-# type.
-#
-# Tests are then run by using puppet apply --noop (to check for compilation
-# errors and view a log of events) or by fully applying the test in a virtual
-# environment (to compare the resulting system state to the desired state).
-#
-# Learn more about module testing here:
-# http://docs.puppetlabs.com/guides/tests_smoke.html
-#
-include puppet_authorization
+puppet_authorization { '/tmp/auth_no_hdr_certinfo.conf':
+  version                => 1,
+  allow_header_cert_info => false,
+}
+
+puppet_authorization { '/tmp/auth_hdr_certinfo.conf':
+  version                => 2,
+  allow_header_cert_info => true,
+}

--- a/tests/rule.pp
+++ b/tests/rule.pp
@@ -1,0 +1,59 @@
+$auth_file = '/tmp/auth.conf'
+
+puppet_authorization { $auth_file:
+  version                => 1,
+  allow_header_cert_info => true,
+}
+
+puppet_authorization::rule { 'allow all authenticated for environments':
+  ensure               => present,
+  match_request_path   => '/puppet/v3/environments',
+  match_request_type   => 'path',
+  match_request_method => ['get','post'],
+  allow                => '*',
+  path                 => $auth_file,
+  require              => Puppet_authorization[$auth_file],
+}
+
+puppet_authorization::rule { 'allow admin and own nodes for catalog':
+  ensure               => present,
+  match_request_path   => '^/puppet/v3/catalog/([^/]+)$',
+  match_request_type   => 'regex',
+  match_request_method => ['get','post'],
+  allow                => ['admin.host.com', '$1', '/admins\.com$/'],
+  path                 => $auth_file,
+  require              => Puppet_authorization[$auth_file],
+}
+
+puppet_authorization::rule { 'allow everyone for certificate':
+  ensure                => present,
+  match_request_path    => '/puppet-ca/v1/certificate',
+  match_request_type    => 'path',
+  match_request_method  => 'get',
+  allow_unauthenticated => true,
+  path                  => $auth_file,
+  require               => Puppet_authorization[$auth_file],
+}
+
+puppet_authorization::rule { 'deny all catalog for protected environments':
+  ensure                     => present,
+  match_request_path         => '/puppet/v3/catalog/',
+  match_request_type         => 'path',
+  match_request_query_params => {
+    'environment' => [ 'secure', 'private' ]},
+  deny                       => '*',
+  path                       => $auth_file,
+  sort_order                 => 100,
+  require                    => Puppet_authorization[$auth_file],
+}
+
+puppet_authorization::rule { 'deny some shadowed by environment allow all':
+  ensure             => present,
+  match_request_path => '/puppet/v3/environments',
+  match_request_type => 'path',
+  deny               => ['denyone.host.com','/\.denydomain\.org$/'],
+  path               => $auth_file,
+  sort_order         => 750,
+  require            => Puppet_authorization[$auth_file],
+}
+


### PR DESCRIPTION
This commit converts the `puppet_authorization` class to a defined
resource type.  This allows for multiple `auth.conf` files to be created
when applying a single catalog.  References to puppetserver's auth.conf
as being the default path were removed.  Some more complete test
manifests for init and rule were also added.
