### PR TITLE
(maint) Incorrect hocon dependency in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-concat","version_requirement":">= 1.1.1 < 2.0.0"},
-    {"name":"puppetlabs-hocon","version_requirement":"> 0.9.3 < 1.0.0"}
+    {"name":"puppetlabs-hocon","version_requirement":">= 0.9.3 < 1.0.0"}
   ]
 }
 


### PR DESCRIPTION
This module depends on the array_element feature that was added in
puppetlabs-hocon 0.9.3, but the metadata listed the dependency as >
0.9.3. It should actually be >=.
