### PR TITLE
(MAINT) Fix set_value to only consider rule name

### DIFF
--- a/lib/puppet/provider/hocon_setting/puppet_authorization.rb
+++ b/lib/puppet/provider/hocon_setting/puppet_authorization.rb
@@ -1,23 +1,16 @@
 Puppet::Type.type(:hocon_setting).provide(:puppet_authorization, :parent => Puppet::Type.type(:hocon_setting).provider(:ruby)) do
   def set_value(value_to_set)
-    if resource[:type] == 'array_element'
-      tmp_val = []
-      val = value
-      Array(val).each do |v|
-        tmp_val << v
+    if resource[:type] == 'array_element' && resource[:setting] == 'authorization.rules'
+      # Prevent duplicate rules by removing existing ones that have the same
+      # rule name as the new value_to_set.
+      tmp_val = Array(value).reject do |existing|
+        value_to_set.any? { |new_val| existing['name'] == new_val['name'] }
       end
-      Array(value_to_set).each do |v|
-        unless tmp_val.include?(v)
-          tmp_val << v
-        end
-      end
-
+      tmp_val.concat(value_to_set)
       tmp_val.sort_by! { |rule| [rule['sort-order'], rule['name']] }
 
       new_value = Hocon::ConfigValueFactory.from_any_ref(tmp_val, nil)
-
       conf_file_modified = conf_file.set_config_value(setting, new_value)
-
       return conf_file_modified
     else
       super


### PR DESCRIPTION
This dumbs down rule equality checking in the provider's set_value
method to only consider rule['name'] when preventing duplicates.

Prior to this commit, rules would be duplicated in the auth.conf file
because a full object equality comparison was failing to recognize the
value_to_set was already present in the configuration file.

It's possible that a similar change will need to be made to remove_value
and possibly exists?, but those changes are still being decided.
