### PR TITLE
(FM-3766) Easier ensure=>absent support

### DIFF
--- a/lib/puppet/provider/hocon_setting/puppet_authorization.rb
+++ b/lib/puppet/provider/hocon_setting/puppet_authorization.rb
@@ -16,4 +16,34 @@ Puppet::Type.type(:hocon_setting).provide(:puppet_authorization, :parent => Pupp
       super
     end
   end
+
+  def remove_value(value_to_remove)
+    if resource[:type] == 'array_element' && resource[:setting] == 'authorization.rules'
+      # Similar to set_value, only consider the rule name when looking for the
+      # rule to remove.
+      new_value_tmp = Array(value).reject do |existing|
+        Array(value_to_remove).any? { |v| existing['name'] == v['name'] }
+      end
+
+      new_value = Hocon::ConfigValueFactory.from_any_ref(new_value_tmp, nil)
+      conf_file_modified = conf_file.set_config_value(setting, new_value)
+      return conf_file_modified
+    else
+      super
+    end
+  end
+
+  def exists?
+    if resource[:type] == 'array_element' &&
+       resource[:setting] == 'authorization.rules' &&
+       resource[:ensure] == :absent
+      # Similar to remove_value, only consider rule name when looking for the
+      # rule to delete.
+      value.any? do |existing|
+        Array(@resource[:value]).any? { |v| existing['name'] == v['name'] }
+      end
+    else
+      super
+    end
+  end
 end

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -1,32 +1,34 @@
 define puppet_authorization::rule (
-  String $match_request_path,
-  Enum['path', 'regex'] $match_request_type,
+  Optional[String] $match_request_path                        = undef,
+  Optional[Enum['path', 'regex']] $match_request_type         = undef,
   String $path,
-  Enum['present', 'absent'] $ensure = 'present',
-  String $rule_name = $name,
-  Variant[Array, String, Undef] $allow = undef,
-  Boolean $allow_unauthenticated = false,
-  Variant[Array, String, Undef] $deny = undef,
-  Variant[Array, String, Undef] $match_request_method = undef,
-  Hash $match_request_query_params = {},
-  Integer $sort_order = 200
+  Enum['present', 'absent'] $ensure                           = 'present',
+  String $rule_name                                           = $name,
+  Variant[Array[String], String, Undef] $allow                = undef,
+  Boolean $allow_unauthenticated                              = false,
+  Variant[Array[String], String, Undef] $deny                 = undef,
+  Variant[Array[String], String, Undef] $match_request_method = undef,
+  Hash $match_request_query_params                            = {},
+  Integer $sort_order                                         = 200
 ) {
-  if $match_request_method =~ String {
-    validate_re($match_request_method, '^(put|post|get|head|delete)$')
-  } elsif $match_request_method =~ Array {
-    $match_request_method.each |$method| {
-      validate_re($method, '^(put|post|get|head|delete)$')
+  if $ensure == 'present' {
+    if $match_request_method =~ String {
+      validate_re($match_request_method, '^(put|post|get|head|delete)$')
+    } elsif $match_request_method =~ Array {
+      $match_request_method.each |$method| {
+        validate_re($method, '^(put|post|get|head|delete)$')
+      }
     }
-  }
 
-  validate_absolute_path($path)
+    validate_absolute_path($path)
 
-  if $allow_unauthenticated and ($allow or $deny) {
-    fail(
-      '$allow and $deny cannot be specified if $allow_unauthenticated is true')
-  } elsif ! $allow and ! $deny and ! $allow_unauthenticated {
-    fail(
-      'One of $allow or $deny is required if $allow_unauthenticated is false')
+    if $allow_unauthenticated and ($allow or $deny) {
+      fail(
+        '$allow and $deny cannot be specified if $allow_unauthenticated is true')
+    } elsif ! $allow and ! $deny and ! $allow_unauthenticated {
+      fail(
+        'One of $allow or $deny is required if $allow_unauthenticated is false')
+    }
   }
 
   if $match_request_method {

--- a/spec/defines/rules_spec.rb
+++ b/spec/defines/rules_spec.rb
@@ -297,4 +297,27 @@ describe 'puppet_authorization::rule', :type => :define do
       end
     end
   end
+
+  context 'class parameters' do
+    context 'not required when ensure=>absent' do
+      let(:params) {{ :ensure => 'absent', :path => '/tmp/foo' }}
+
+      it { is_expected.to contain_hocon_setting('rule-rule').with({
+        :ensure   => 'absent',
+        :path     => '/tmp/foo',
+        :setting  => 'authorization.rules',
+        :type     => 'array_element',
+        :provider => 'puppet_authorization',
+        :value    => {
+          'match-request' => {
+            'path'         => 'undef',
+            'type'         => 'undef',
+            'query-params' => {},
+          },
+          'allow-unauthenticated' => false,
+          'name'                  => 'rule',
+          'sort-order'            => 200
+        }})}
+    end
+  end
 end


### PR DESCRIPTION
This commit loosens most of the required parameters to only be required
when creating rules, and not when deleting them (e.g. ensure=>absent).
The rule class parameters have been typed as optional and given default
values (mostly just `undef`), and validation happens only during
ensure=>present.
