### PR TITLE
(FM-3807) Add rules when target array does not already exist

### DIFF
--- a/spec/unit/provider/puppet_authorization_hocon_rule/ruby_spec.rb
+++ b/spec/unit/provider/puppet_authorization_hocon_rule/ruby_spec.rb
@@ -5,9 +5,9 @@ provider_class = Puppet::Type.type(:puppet_authorization_hocon_rule).provider(:r
 describe provider_class do
   include PuppetlabsSpec::Files
 
-  context 'rules array' do
-    let(:tmpfile) { tmpfilename('puppet_authorization_rule_test.conf') }
+  let(:tmpfile) { tmpfilename('puppet_authorization_rule_test.conf') }
 
+  context 'rules setting already in target file as non-empty array' do
     before :each do
       File.open(tmpfile, 'w') do |f|
         f.write(<<-EOS)
@@ -94,4 +94,87 @@ authorization: {
 EOS
     end
   end
+
+  context 'rules setting not already in target file' do
+    it 'should create the rule setting as an array and add a rule to it' do
+      resource = Puppet::Type::Puppet_authorization_hocon_rule.new(
+          :title => 'bar rule',
+          :path  => tmpfile,
+          :value => {
+              'match-request' => {
+                  'path' => '/bar',
+                  'type' => 'path'
+              },
+              'allow'      => 'bar',
+              'name'       => 'bar-rule',
+              'sort-order' => 777 })
+
+      provider = provider_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      expect(File.read(tmpfile)).to eq(<<-EOS)
+authorization : {
+  rules : [
+      {
+          "allow" : "bar",
+          "match-request" : {
+              "path" : "/bar",
+              "type" : "path"
+          },
+          "name" : "bar-rule",
+          "sort-order" : 777
+      }
+  
+  ]
+}
+      EOS
+    end
+  end
+
+  context 'rules setting in target file not an array' do
+    it 'should rewrite the rules setting as an array and add a rule to it' do
+      File.open(tmpfile, 'w') do |f|
+        f.write(<<-EOS)
+authorization: {
+  version: 1
+  rules: 42
+}
+        EOS
+      end
+
+      resource = Puppet::Type::Puppet_authorization_hocon_rule.new(
+          :title => 'bar rule',
+          :path  => tmpfile,
+          :value => {
+              'match-request' => {
+                  'path' => '/bar',
+                  'type' => 'path'
+              },
+              'allow'      => 'bar',
+              'name'       => 'bar-rule',
+              'sort-order' => 777 })
+
+      provider = provider_class.new(resource)
+      expect(provider.exists?).to be false
+      provider.create
+      expect(File.read(tmpfile)).to eq(<<-EOS)
+authorization: {
+  version: 1
+  rules: [
+      {
+          "allow" : "bar",
+          "match-request" : {
+              "path" : "/bar",
+              "type" : "path"
+          },
+          "name" : "bar-rule",
+          "sort-order" : 777
+      }
+  
+  ]
+}
+      EOS
+    end
+  end
+
 end

--- a/tests/rule.pp
+++ b/tests/rule.pp
@@ -1,10 +1,5 @@
 $auth_file = '/tmp/auth.conf'
 
-puppet_authorization { $auth_file:
-  version                => 1,
-  allow_header_cert_info => true,
-}
-
 puppet_authorization::rule { 'allow all authenticated for environments':
   ensure               => present,
   match_request_path   => '/puppet/v3/environments',
@@ -12,7 +7,6 @@ puppet_authorization::rule { 'allow all authenticated for environments':
   match_request_method => ['get','post'],
   allow                => '*',
   path                 => $auth_file,
-  require              => Puppet_authorization[$auth_file],
 }
 
 puppet_authorization::rule { 'allow admin and own nodes for catalog':
@@ -22,7 +16,6 @@ puppet_authorization::rule { 'allow admin and own nodes for catalog':
   match_request_method => ['get','post'],
   allow                => ['admin.host.com', '$1', '/admins\.com$/'],
   path                 => $auth_file,
-  require              => Puppet_authorization[$auth_file],
 }
 
 puppet_authorization::rule { 'allow everyone for certificate':
@@ -32,7 +25,6 @@ puppet_authorization::rule { 'allow everyone for certificate':
   match_request_method  => 'get',
   allow_unauthenticated => true,
   path                  => $auth_file,
-  require               => Puppet_authorization[$auth_file],
 }
 
 puppet_authorization::rule { 'deny all catalog for protected environments':
@@ -44,7 +36,6 @@ puppet_authorization::rule { 'deny all catalog for protected environments':
   deny                       => '*',
   path                       => $auth_file,
   sort_order                 => 100,
-  require                    => Puppet_authorization[$auth_file],
 }
 
 puppet_authorization::rule { 'deny some shadowed by environment allow all':
@@ -54,6 +45,4 @@ puppet_authorization::rule { 'deny some shadowed by environment allow all':
   deny               => ['denyone.host.com','/\.denydomain\.org$/'],
   path               => $auth_file,
   sort_order         => 750,
-  require            => Puppet_authorization[$auth_file],
 }
-


### PR DESCRIPTION
This commit allows the provider to create a new array and add a rule to
it even when the rule setting in the target file does not 
contain an array.  In previous commits, an attempt to add a rule in this
scenario would generate an error and no changes would be applied to the
target file.
