### PR TITLE
update concat version dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       "ref": "4.6.0"
     "concat":
       "repo": "git://github.com/puppetlabs/puppetlabs-concat.git"
-      "ref": "1.1.1"
+      "ref": "master"
     "hocon":
       "repo": "git://github.com/puppetlabs/puppetlabs-hocon.git"
       "ref": "master"

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 1.1.1 < 2.0.0"},
+    {"name":"puppetlabs-concat","version_requirement":">= 1.1.1 < 3.0.0"},
     {"name":"puppetlabs-hocon","version_requirement":">= 0.9.3 < 1.0.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
From my test, puppet_authorization works without problems with concat 2.1, so updating the dependency from '< 2.0.0' to '< 3.0.0' would remove some warnings.