### PR TITLE
(PE-14870) Add support for extensions matching 

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ Adds individual rules to auth.conf.
 
 * `rule_name`: The `name` setting for the rule. Valid options: a string. Defaults to `name`.
 
-* `allow`: The `allow` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true. Valid options: a hash, a string or an array of strings and/or hashses. A hash here must contain only one of `extensions` or `certname`. Defaults to undef. For more details on the `allow` setting, see https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md#allow.
+* `allow`: The `allow` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true. Valid options: a hash, a string or an array of strings and/or hashes. A hash here must contain only one of `extensions` or `certname`. Defaults to undef. For more details on the `allow` setting, see https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md#allow.
 
-* `deny`: The `deny` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true.  Valid options: a hash, a string or an array of strings and/or hashses. A hash here must contain only one of `extensions` or `certname`. Defaults to undef. For more details on the `deny` setting, see https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md#deny.
+* `deny`: The `deny` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true.  Valid options: a hash, a string or an array of strings and/or hashes. A hash here must contain only one of `extensions` or `certname`. Defaults to undef. For more details on the `deny` setting, see https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md#deny.
 
 * `allow_unauthenticated`: The `allow_unauthenticated` setting for the rule. Cannot be set to true along with `deny` or `allow`. Valid options: true, false. Defaults to false.
 

--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ Adds individual rules to auth.conf.
 
 * `rule_name`: The `name` setting for the rule. Valid options: a string. Defaults to `name`.
 
-* `allow`: The `allow` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true. Valid options: a string or an array of strings. Defaults to undef.
+* `allow`: The `allow` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true. Valid options: a hash, a string or an array of strings and/or hashses. A hash here must contain only one of `extensions` or `certname`. Defaults to undef. For more details on the `allow` setting, see https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md#allow.
 
-* `deny`: The `deny` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true. Valid options: a string or an array of strings. Defaults to undef.
+* `deny`: The `deny` setting for the rule. Cannot be set along with an `allow_unauthenticated` value of true.  Valid options: a hash, a string or an array of strings and/or hashses. A hash here must contain only one of `extensions` or `certname`. Defaults to undef. For more details on the `deny` setting, see https://github.com/puppetlabs/trapperkeeper-authorization/blob/master/doc/authorization-config.md#deny.
 
 * `allow_unauthenticated`: The `allow_unauthenticated` setting for the rule. Cannot be set to true along with `deny` or `allow`. Valid options: true, false. Defaults to false.
 

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -1,15 +1,15 @@
 define puppet_authorization::rule (
-  Optional[String] $match_request_path                        = undef,
-  Optional[Enum['path', 'regex']] $match_request_type         = undef,
+  Optional[String] $match_request_path                                = undef,
+  Optional[Enum['path', 'regex']] $match_request_type                 = undef,
   String $path,
-  Enum['present', 'absent'] $ensure                           = 'present',
-  String $rule_name                                           = $name,
-  Variant[Array[String], String, Undef] $allow                = undef,
-  Boolean $allow_unauthenticated                              = false,
-  Variant[Array[String], String, Undef] $deny                 = undef,
-  Variant[Array[String], String, Undef] $match_request_method = undef,
-  Hash $match_request_query_params                            = {},
-  Integer $sort_order                                         = 200
+  Enum['present', 'absent'] $ensure                                   = 'present',
+  String $rule_name                                                   = $name,
+  Variant[Array[Variant[String, Hash]], String, Hash, Undef] $allow   = undef,
+  Boolean $allow_unauthenticated                                      = false,
+  Variant[Array[Variant[String, Hash]], String, Hash, Undef] $deny    = undef,
+  Variant[Array[String], String, Undef] $match_request_method         = undef,
+  Hash $match_request_query_params                                    = {},
+  Integer $sort_order                                                 = 200
 ) {
   if $ensure == 'present' {
     if $match_request_method =~ String {

--- a/spec/defines/rules_spec.rb
+++ b/spec/defines/rules_spec.rb
@@ -120,6 +120,31 @@ describe 'puppet_authorization::rule', :type => :define do
     })}
   end
 
+  context 'default, multiple allows and denies with extensions' do
+    let(:params_override) do
+      {
+        :allow => ['foo', 'bar', {'extensions' => {'foo' => 'bar'}}],
+        :deny  => {'extensions' => {'foo' => ['bar', 'baz', 'biz']}},
+      }
+    end
+
+    it { is_expected.to contain_puppet_authorization_hocon_rule('rule-rule').with({
+      :ensure   => 'present',
+      :path     => '/tmp/foo',
+      :value    => {
+        'match-request' => {
+          'path'         => '/foo',
+          'type'         => 'path',
+          'query-params' => {},
+        },
+        'allow'         => ['foo', 'bar', {'extensions' => {'foo' => 'bar'}}],
+        'deny'          => {'extensions' => {'foo' => ['bar', 'baz', 'biz']}},
+        'name'          => 'rule',
+        'sort-order'    => 200,
+      },
+    })}
+  end
+
   context 'allow_unauthenticated' do
     let(:params_override) do
       {

--- a/spec/unit/puppet_authorization_hocon_rule_spec.rb
+++ b/spec/unit/puppet_authorization_hocon_rule_spec.rb
@@ -32,6 +32,40 @@ describe Puppet::Type.type(:puppet_authorization_hocon_rule) do
       Puppet::Error, /Value must be a hash/
   end
 
+  context 'raises an error with invalid allow/deny values' do
+    it 'raises an error if both certname and extensions are in the same map' do
+      expect { resource[:value] = {'allow' => {'certname' => 'foo', 'extensions' => {'bar' => 'baz'}}} }.to \
+        raise_error Puppet::Error, /Only one of 'certname' and 'extensions' are allowed keys in a allow hash./
+    end
+
+    it 'raises an error if an unknown key is in the allow/deny map' do
+      expect { resource[:value] = {'deny' => {'goodness me' => 'foo', 'extensions' => {'bar' => 'baz'}}} }.to \
+        raise_error Puppet::Error, /Only one of 'certname' and 'extensions' are allowed keys in a deny hash. Found 'goodness me'./
+    end
+
+    it 'raises an error if neither certname nor extensions are in an allow/deny map' do
+      expect { resource[:value] = {'allow' => {}} }.to \
+        raise_error Puppet::Error, /Only one of 'certname' and 'extensions' are allowed keys in a allow hash./
+    end
+
+    context 'checks maps in allow/deny arrays' do
+      it 'raises an error if both certname and extensions are in the same map' do
+        expect { resource[:value] = {'allow' => ['node1', 'node2', {'certname' => 'foo', 'extensions' => {'bar' => 'baz'}}]} }.to \
+          raise_error Puppet::Error, /Only one of 'certname' and 'extensions' are allowed keys in a allow hash./
+      end
+
+      it 'raises an error if an unknown key is in the allow/deny map' do
+        expect { resource[:value] = {'deny' => [{'goodness me' => 'foo', 'extensions' => {'bar' => 'baz'}}, 'node3', { 'extensions' => {'bar' => 'baz'}}]} }.to \
+          raise_error Puppet::Error, /Only one of 'certname' and 'extensions' are allowed keys in a deny hash. Found 'goodness me'./
+      end
+
+      it 'raises an error if neither certname nor extensions are in an allow/deny map' do
+        expect { resource[:value] = {'allow' => [{}, {'certname' => 'foo'}]} }.to \
+          raise_error Puppet::Error, /Only one of 'certname' and 'extensions' are allowed keys in a allow hash./
+      end
+    end
+  end
+
   it 'raises an error with invalid path values' do
     expect { resource[:path] = "not/absolute/path" }.to raise_error \
       Puppet::Error, /File paths must be fully qualified/


### PR DESCRIPTION
With trapperkeeper-authorization 0.6.0, SSL Certificate extensions are
valid in allow/deny rules (as are certnames). This commit updates the
validation to ensure that a valid allow/deny entry has been supplied so
that a user doesn't get surprising errors when using the feature.
In order to support passing ssl extensions in allow and deny rules, the
data types in the defined type rule need to be updated to include hashes
on their own and arrays of hashes and strings.