### PR TITLE
update dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     "stdlib":
       "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      "ref": "4.6.0"
+      "ref": "master"
     "concat":
       "repo": "git://github.com/puppetlabs/puppetlabs-concat.git"
       "ref": "master"

--- a/metadata.json
+++ b/metadata.json
@@ -9,8 +9,8 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 1.1.1 < 3.0.0"},
-    {"name":"puppetlabs-hocon","version_requirement":">= 0.9.3 < 1.0.0"}
+    {"name":"puppetlabs-concat","version_requirement":">= 1.1.1 < 5.0.0"},
+    {"name":"puppetlabs-hocon","version_requirement":">= 0.9.3 < 2.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
As the only change in -concat and -hocon was the dropping of Puppet 3.x support, this should be fine.