### PR TITLE
(MODULES-7844) Update stdlib and concat dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.6
-    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+  - rvm: 2.4.4
+    env: PUPPET_VERSION="~> 5.0" STRICT_VARIABLES="yes"
+  - rvm: 2.5.1
+    env: PUPPET_VERSION="~> 6.0" STRICT_VARIABLES="yes"
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gem 'facter', '>= 1.7.0'
 group :development, :unit_tests do
   gem 'puppetlabs_spec_helper', '>= 0.8.2'
   gem 'puppet-lint', '>= 1.0.0'
-  gem 'hocon', '~> 0.9.3', :require => false
+  gem 'hocon', '~> 1.0', :require => false
 end

--- a/metadata.json
+++ b/metadata.json
@@ -52,14 +52,16 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",
-        "14.04"
+        "14.04",
+        "16.04",
+        "18.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,8 +8,8 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-puppet_authorization",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 1.1.1 < 5.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 6.0.0"},
+    {"name":"puppetlabs-concat","version_requirement":">= 1.1.1 < 6.0.0"},
     {"name":"puppetlabs-hocon","version_requirement":">= 0.9.3 < 2.0.0"}
   ],
   "operatingsystem_support": [

--- a/spec/defines/rules_spec.rb
+++ b/spec/defines/rules_spec.rb
@@ -1,3 +1,4 @@
+require 'rubygems/version'
 require 'spec_helper'
 describe 'puppet_authorization::rule', :type => :define do
   let :pre_condition do
@@ -310,6 +311,13 @@ describe 'puppet_authorization::rule', :type => :define do
 
   context 'class parameters' do
     context 'not required when ensure=>absent' do
+      # Puppet 6.0 and newer convert undef values in hashes to `nil`.
+      empty_value = if Gem::Requirement.new('>= 6.0').satisfied_by?(Gem::Version.new(Puppet.version))
+                      nil
+                    else
+                      'undef'
+                    end
+
       let(:params) {{ :ensure => 'absent', :path => '/tmp/foo' }}
 
       it { is_expected.to contain_puppet_authorization_hocon_rule('rule-rule').with({
@@ -317,8 +325,8 @@ describe 'puppet_authorization::rule', :type => :define do
         :path     => '/tmp/foo',
         :value    => {
           'match-request' => {
-            'path'         => 'undef',
-            'type'         => 'undef',
+            'path'         => empty_value,
+            'type'         => empty_value,
             'query-params' => {},
           },
           'allow-unauthenticated' => false,

--- a/spec/unit/provider/puppet_authorization_hocon_rule/ruby_spec.rb
+++ b/spec/unit/provider/puppet_authorization_hocon_rule/ruby_spec.rb
@@ -50,23 +50,23 @@ authorization: {
   version: 1
   rules: [
       {
-          "allow" : "foo",
-          "match-request" : {
-              "path" : "/foo",
-              "type" : "path"
+          "allow": "foo",
+          "match-request": {
+              "path": "/foo",
+              "type": "path"
           },
-          "name" : "foo-rule",
-          "sort-order" : 666
+          "name": "foo-rule",
+          "sort-order": 666
       }
   ,
       {
-          "allow" : "bar",
-          "match-request" : {
-              "path" : "/bar",
-              "type" : "path"
+          "allow": "bar",
+          "match-request": {
+              "path": "/bar",
+              "type": "path"
           },
-          "name" : "bar-rule",
-          "sort-order" : 777
+          "name": "bar-rule",
+          "sort-order": 777
       }
   
   ]
@@ -113,16 +113,16 @@ EOS
       expect(provider.exists?).to be false
       provider.create
       expect(File.read(tmpfile)).to eq(<<-EOS)
-authorization : {
-  rules : [
+authorization: {
+  rules: [
       {
-          "allow" : "bar",
-          "match-request" : {
-              "path" : "/bar",
-              "type" : "path"
+          "allow": "bar",
+          "match-request": {
+              "path": "/bar",
+              "type": "path"
           },
-          "name" : "bar-rule",
-          "sort-order" : 777
+          "name": "bar-rule",
+          "sort-order": 777
       }
   
   ]
@@ -162,13 +162,13 @@ authorization: {
   version: 1
   rules: [
       {
-          "allow" : "bar",
-          "match-request" : {
-              "path" : "/bar",
-              "type" : "path"
+          "allow": "bar",
+          "match-request": {
+              "path": "/bar",
+              "type": "path"
           },
-          "name" : "bar-rule",
-          "sort-order" : 777
+          "name": "bar-rule",
+          "sort-order": 777
       }
   
   ]


### PR DESCRIPTION
This patchset updates the stdlib and concat dependencies so that `puppet_authorization` can be installed into an environment using the recently released 5.0 versions of both modules. The test suite is also extended to cover Puppet 5.x and Puppet 6.x.