### PR TITLE
Drop unsupported operating systems

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -33,7 +32,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -41,31 +39,19 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11 SP1",
         "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04",
-        "16.04",
         "18.04"
       ]
     }


### PR DESCRIPTION
Dropped support for: 
* EL 6
* Scientific Linux
* SLES 11
* Ubuntu 12.04, 14.04, and 16.04